### PR TITLE
Update VSCode workspace configs to use the built in `organizeImports`

### DIFF
--- a/yana-backend/.vscode/extensions.json
+++ b/yana-backend/.vscode/extensions.json
@@ -1,9 +1,5 @@
 {
-  "recommendations": [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "rbbit.typescript-hero"
-  ],
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],
   "unwantedRecommendations": [
     "hookyqr.beautify",
     "dbaeumer.jshint",

--- a/yana-backend/.vscode/settings.json
+++ b/yana-backend/.vscode/settings.json
@@ -20,6 +20,7 @@
   "editor.formatOnSave": true,
   "editor.formatOnType": true,
   "editor.codeActionsOnSave": {
+    "source.organizeImports": true,
     "source.fixAll": true
   },
   "typescriptHero.imports.organizeOnSave": true

--- a/yana-frontend/.vscode/settings.json
+++ b/yana-frontend/.vscode/settings.json
@@ -22,6 +22,7 @@
   "editor.formatOnSave": true,
   "editor.formatOnType": true,
   "editor.codeActionsOnSave": {
+    "source.organizeImports": true,
     "source.fixAll": true
   }
 }


### PR DESCRIPTION
This prevents race conditions with the ESLint/Prettier formatting, which could sometimes result in badly formatted files.