### PR TITLE
[frontend] Fix the filter options fetch to actually cache

### DIFF
--- a/yana-frontend/src/store/actions.js
+++ b/yana-frontend/src/store/actions.js
@@ -1,6 +1,7 @@
 import { axiosInstance } from 'boot/axios';
 import _cloneDeep from 'lodash-es/cloneDeep';
 import _isEmpty from 'lodash-es/isEmpty';
+import _keyBy from 'lodash-es/keyBy';
 import _uniq from 'lodash-es/uniq';
 import {
   APPLY_FILTER,
@@ -16,12 +17,13 @@ export default {
   async [FETCH_FILTER_OPTIONS]({ state, commit }) {
     // Only fetch them if we don't already have them.
     // This means once we fetch them we cache them for the lifetime of the app instance. (We may want to add a time based expiry later).
-    if (state.filterOptions.length) {
+    if (!_isEmpty(state.filterOptions)) {
       return Promise.resolve();
     }
 
     const response = await axiosInstance.get('resources/filters');
-    commit(SET_FILTER_OPTIONS, response.data);
+    const optionsMap = _keyBy(response.data, 'field');
+    commit(SET_FILTER_OPTIONS, optionsMap);
   },
 
   async [APPLY_FILTER]({ state, dispatch, commit }, { field, value }) {

--- a/yana-frontend/src/store/mutations.js
+++ b/yana-frontend/src/store/mutations.js
@@ -1,9 +1,8 @@
-import _keyBy from 'lodash/keyBy';
 import { SET_FILTERS, SET_FILTER_OPTIONS, SET_RESOURCE, SET_RESOURCES } from './mutations.types';
 
 export default {
   [SET_FILTER_OPTIONS](state, options) {
-    state.filterOptions = _keyBy(options, 'field');
+    state.filterOptions = options;
   },
 
   [SET_FILTERS](state, filters) {

--- a/yana-frontend/src/store/state.js
+++ b/yana-frontend/src/store/state.js
@@ -1,6 +1,6 @@
 export default function () {
   return {
-    filterOptions: [],
+    filterOptions: {},
     filters: {},
     resources: [],
     resource: null,


### PR DESCRIPTION
There was a mismatch in the way `filterOptions` was being initialised, set and read – it should always be an object where the key is the filter field.

This now ensures that the filter options will be cached in the application instance once loaded.