### PR TITLE
[frontend] Resources UI tweaks

### DIFF
--- a/ysm-frontend/src/components/resources/ContentItem.spec.js
+++ b/ysm-frontend/src/components/resources/ContentItem.spec.js
@@ -1,0 +1,24 @@
+import * as Quasar from 'quasar';
+import { mountQuasar } from '~/test/jest/utils';
+import ContentItem from './ContentItem.vue';
+
+const QCard = Quasar.QCard;
+
+describe('components/resources/ContentItem.vue', () => {
+  const wrapper = mountQuasar(ContentItem, {
+    propsData: { item: {} },
+  });
+  const vm = wrapper.vm;
+
+  it('should be instantiated', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('should have the expected component name', () => {
+    expect(vm.$options.name).toBe('ContentItem');
+  });
+
+  it('should contain a QCard component', () => {
+    expect(wrapper.findAllComponents(QCard)).toHaveLength(1);
+  });
+});

--- a/ysm-frontend/src/components/resources/ContentItem.vue
+++ b/ysm-frontend/src/components/resources/ContentItem.vue
@@ -1,0 +1,36 @@
+<template>
+  <q-card flat bordered>
+    <q-card-section>
+      <div class="text-subtitle2 text-weight-bold">
+        {{ item.title }}
+      </div>
+      <!-- eslint-disable vue/no-v-html -->
+      <div
+        v-if="item.descriptionHtml"
+        class="q-mt-sm text-body2"
+        v-html="item.descriptionHtml"
+      ></div>
+
+      <div class="q-mt-sm">
+        <template v-if="item.type === 'external_link'">
+          <a :href="item.link" target="_blank" rel="noopener">{{ item.link }}</a>
+        </template>
+      </div>
+    </q-card-section>
+  </q-card>
+</template>
+
+<script>
+export default {
+  name: 'ContentItem',
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {};
+  },
+};
+</script>

--- a/ysm-frontend/src/pages/resources/Resource.vue
+++ b/ysm-frontend/src/pages/resources/Resource.vue
@@ -3,11 +3,11 @@
     <div v-if="resource" class="q-pa-md">
       <h1 class="text-h5">
         {{ resource.title }}
-        <q-icon :name="'eva-' + resource.icon" class="q-ml-sm text-primary"></q-icon>
+        <q-icon :name="'eva-' + resource.icon" class="q-ml-sm float-right text-primary"></q-icon>
       </h1>
       <h2 v-if="resource.subtitle" class="text-h6">{{ resource.subtitle }}</h2>
 
-      <div class="q-mt-md">
+      <div class="q-mt-sm">
         <resource-countries-list
           :countries="resource.countries"
           :mappings="filterOptionsForField('countries')"
@@ -17,15 +17,14 @@
       <!-- eslint-disable vue/no-v-html -->
       <div class="q-mt-md text-body1" v-html="resource.descriptionHtml"></div>
 
-      <q-card v-for="c in resource.content" :key="c.id" flat bordered class="q-mt-md">
-        <template v-if="c.type === 'external_link'">
-          <q-card-section>
-            <!-- eslint-disable vue/no-v-html -->
-            <div v-if="c.descriptionHtml" class="text-body1" v-html="c.descriptionHtml"></div>
-            <a :href="c.link" target="_blank" rel="noopener">{{ c.title }}</a>
-          </q-card-section>
-        </template>
-      </q-card>
+      <div class="q-py-sm">
+        <content-item
+          v-for="i in resource.content"
+          :key="i.id"
+          :item="i"
+          class="q-mt-sm"
+        ></content-item>
+      </div>
     </div>
   </q-page>
 </template>
@@ -37,10 +36,11 @@ import { Notify } from 'quasar';
 import { FETCH_RESOURCE, FETCH_FILTER_OPTIONS } from 'src/store/actions.types';
 
 import ResourceCountriesList from 'components/resources/ResourceCountriesList';
+import ContentItem from 'components/resources/ContentItem';
 
 export default {
   name: 'ResourcePage',
-  components: { ResourceCountriesList },
+  components: { ResourceCountriesList, ContentItem },
   preFetch({ store, currentRoute, redirect }) {
     const fetchFilterOptionsPromise = store.dispatch(FETCH_FILTER_OPTIONS);
 


### PR DESCRIPTION
- Make the icon position consistent between the resource cards and resource view.
- Tweak spacings to tighten up things.
- Separate out the content item rendering into a dedicated component.
- New layout for content items: title then description then the content item type specific data (in the case of external links, this will show the link itself).