### PR TITLE
[frontend] Let the Service Worker update immediately

### DIFF
--- a/ysm-frontend/quasar.conf.js
+++ b/ysm-frontend/quasar.conf.js
@@ -113,7 +113,11 @@ module.exports = function (/* ctx */) {
     // https://quasar.dev/quasar-cli/developing-pwa/configuring-pwa
     pwa: {
       workboxPluginMode: 'GenerateSW', // 'GenerateSW' or 'InjectManifest'
-      workboxOptions: {}, // only for GenerateSW
+      workboxOptions: {
+        // only for GenerateSW
+        skipWaiting: true,
+        clientsClaim: true,
+      },
       manifest: {
         name: 'Your Story Matters (YSM)',
         short_name: 'YSM',


### PR DESCRIPTION
This means we won't need to reload the page a second time to activate the new service worker (and thus new assets which are precached).

Important: this only works well with the default GenerateSW workbox mode for Quasar. If we ever customise the Service Worker to other things (like Push) then we'd need to rethink this.