### PR TITLE
API to store user state per resource (as part of their profile)

### DIFF
--- a/ysm-backend/src/profile/profile.controller.spec.ts
+++ b/ysm-backend/src/profile/profile.controller.spec.ts
@@ -34,6 +34,7 @@ describe('Profile Controller', () => {
       const profile: Profile = {
         id: 'foo',
         bookmarkedResources: [],
+        resourceState: {},
       };
 
       profileService.get.mockResolvedValueOnce(profile);
@@ -61,6 +62,16 @@ describe('Profile Controller', () => {
       expect(await controller.removeBookmarkForResource('foo', '123456')).toEqual(undefined);
 
       expect(profileService.removeBookmarkForResource).toHaveBeenCalledWith('foo', '123456');
+    });
+  });
+
+  describe('updateResourceState', () => {
+    it('should call the profile service', async () => {
+      profileService.updateResourceState.mockResolvedValueOnce(undefined);
+
+      expect(await controller.updateResourceState('foo', '123456', { a: 1 })).toEqual(undefined);
+
+      expect(profileService.updateResourceState).toHaveBeenCalledWith('foo', '123456', { a: 1 });
     });
   });
 });

--- a/ysm-backend/src/profile/profile.controller.ts
+++ b/ysm-backend/src/profile/profile.controller.ts
@@ -1,8 +1,8 @@
-import { Controller, Delete, Get, HttpCode, Param, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, Param, Put, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUserId } from '../auth/current-user-id.decorator';
 import { ProfileService } from './profile.service';
-import { Profile } from './profile.types';
+import { Profile, ResourceState } from './profile.types';
 
 @Controller('profile')
 @UseGuards(AuthGuard)
@@ -30,5 +30,15 @@ export class ProfileController {
     @Param('resourceId') resourceId: string,
   ): Promise<void> {
     return this.profileService.removeBookmarkForResource(currentUserId, resourceId);
+  }
+
+  @Put('state/resources/:resourceId')
+  @HttpCode(204)
+  async updateResourceState(
+    @CurrentUserId() currentUserId: string,
+    @Param('resourceId') resourceId: string,
+    @Body() state: ResourceState,
+  ): Promise<void> {
+    return this.profileService.updateResourceState(currentUserId, resourceId, state);
   }
 }

--- a/ysm-backend/src/profile/profile.types.ts
+++ b/ysm-backend/src/profile/profile.types.ts
@@ -1,4 +1,7 @@
 export interface Profile {
   id: string;
   bookmarkedResources: string[];
+  resourceState: Record<string, ResourceState>;
 }
+
+export type ResourceState = Record<string, any>;


### PR DESCRIPTION
- New API: `PUT /profile/state/resources/{resourceId}` with the body containing a JSON object – anything the client wants to set – that will get persisted *as-is* to the user's profile in Firestore.
- The user's profile API now also returns a `resourceState` field, which is a map of `{resourceId}: <JSON data>`.

One important constraint: the max size for the whole user profile document on Firestore is 1MB. This includes bookmarks + all resource state, so we should keep resource state as light as possible.