### PR TITLE
Backend/API to support "preview mode" of content (resources, themes and pages)

### DIFF
--- a/ysm-backend/.env.test
+++ b/ysm-backend/.env.test
@@ -1,2 +1,4 @@
 # Make sure tests don't use a valid Storyblok token - this way, any access to Storyblok will error out and force us to mock out the interaction.
 STORYBLOK_TOKEN=noop
+
+CONTENT_EDITOR_EMAILS=

--- a/ysm-backend/README.md
+++ b/ysm-backend/README.md
@@ -21,6 +21,8 @@ For local development, create a new **`.env.development`** file at the root of t
 STORYBLOK_TOKEN={value}  # The API token from Storyblok (must have 'draft' access)
 
 FIREBASE_SERVICE_ACCOUNT={value}  # The service account JSON object serialised into a string and then base64 encoded
+
+CONTENT_EDITOR_EMAILS={value}  # Optional. A comma separated list of email addresses of the users that are allowed to access preview mode (for viewing draft content from Storyblok)
 ```
 
 #### Env config for tests

--- a/ysm-backend/src/app.module.ts
+++ b/ysm-backend/src/app.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
+import { AuthModule } from './auth/auth.module';
 import { configModuleOptions } from './config-module-options';
+import { PagesModule } from './pages/pages.module';
 import { ProfileModule } from './profile/profile.module';
 import { ResourcesModule } from './resources/resources.module';
 import { ThemesModule } from './themes/themes.module';
-import { PagesModule } from './pages/pages.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { PagesModule } from './pages/pages.module';
     ThemesModule,
     ProfileModule,
     PagesModule,
+    AuthModule,
   ],
   controllers: [AppController],
 })

--- a/ysm-backend/src/auth/auth.guard.ts
+++ b/ysm-backend/src/auth/auth.guard.ts
@@ -1,25 +1,14 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  Inject,
-  Injectable,
-  Logger,
-  UnauthorizedException,
-} from '@nestjs/common';
-import { FIREBASE } from '../firebase/firebase-factory';
-import { firebase, FirebaseServices } from '../firebase/firebase.types';
-import { CURRENT_USER_ID_FIELD } from './constants';
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Request } from 'express';
+import { CURRENT_USER_ID_FIELD } from '../constants';
+import { AuthService } from './auth.service';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  private CHECK_REVOKED = true;
-
-  private logger = new Logger('AuthGuard');
-
-  constructor(@Inject(FIREBASE) private firebase: FirebaseServices) {}
+  constructor(private authService: AuthService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest();
+    const request = context.switchToHttp().getRequest<Request>();
 
     const { authorization } = request.headers;
 
@@ -27,40 +16,10 @@ export class AuthGuard implements CanActivate {
       throw new UnauthorizedException('Unauthorized: missing required Authorization token');
     }
 
-    if (!authorization.startsWith('Bearer ')) {
-      throw new UnauthorizedException(
-        'Unauthorized: auth header not in the required format - should be "Bearer {token}"',
-      );
-    }
+    const decodedToken = await this.authService.parseAuth(authorization);
 
-    const idToken = authorization.split('Bearer ')[1];
-
-    const decodedToken = await this.parseAndValidateToken(idToken);
-
-    const userId = decodedToken.uid;
-
-    if (!decodedToken.email_verified) {
-      this.logger.error(
-        `Unauthorized: user email not verified - user ID: ${userId}. Client should not be making requests with an unverified user.`,
-      );
-
-      throw new UnauthorizedException('Unauthorized: user email not verified');
-    }
-
-    request[CURRENT_USER_ID_FIELD] = userId;
+    request[CURRENT_USER_ID_FIELD] = decodedToken.uid;
 
     return true;
-  }
-
-  private async parseAndValidateToken(token: string): Promise<firebase.auth.DecodedIdToken> {
-    try {
-      const decodedToken = await this.firebase.auth.verifyIdToken(token, this.CHECK_REVOKED);
-
-      return decodedToken;
-    } catch (err) {
-      this.logger.error(`Unauthorized: failed verification with error: ${err.message}`);
-
-      throw new UnauthorizedException('Unauthorized: token is expired or invalid');
-    }
   }
 }

--- a/ysm-backend/src/auth/auth.module.ts
+++ b/ysm-backend/src/auth/auth.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { FirebaseModule } from '../firebase/firebase.module';
+import { AuthService } from './auth.service';
+
+@Global()
+@Module({
+  imports: [FirebaseModule],
+  providers: [AuthService],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/ysm-backend/src/auth/auth.service.spec.ts
+++ b/ysm-backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,38 @@
+import { createMock } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { FIREBASE } from '../firebase/firebase-factory';
+import { FirebaseAuth, FirebaseServices, Firestore } from '../firebase/firebase.types';
+import { AuthService } from './auth.service';
+
+// Note: this service is tested more thoroughly as part of the AuthGuard specs.
+
+describe('AuthService', () => {
+  let mockFirebaseServices: FirebaseServices;
+
+  let service: AuthService;
+
+  beforeEach(async () => {
+    mockFirebaseServices = {
+      auth: createMock<FirebaseAuth>(),
+      firestore: createMock<Firestore>(),
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      shutdown: async () => {},
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: FIREBASE,
+          useValue: mockFirebaseServices,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/ysm-backend/src/auth/auth.service.ts
+++ b/ysm-backend/src/auth/auth.service.ts
@@ -1,0 +1,52 @@
+import {
+  ForbiddenException,
+  Inject,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { FIREBASE } from '../firebase/firebase-factory';
+import { firebase, FirebaseServices } from '../firebase/firebase.types';
+
+@Injectable()
+export class AuthService {
+  private CHECK_REVOKED = true;
+
+  private logger = new Logger('AuthService');
+
+  constructor(@Inject(FIREBASE) private firebase: FirebaseServices) {}
+
+  async parseAuth(header: string): Promise<firebase.auth.DecodedIdToken> {
+    if (!header.startsWith('Bearer ')) {
+      throw new UnauthorizedException(
+        'Unauthorized: auth header not in the required format - should be "Bearer {token}"',
+      );
+    }
+
+    const idToken = header.split('Bearer ')[1];
+
+    const decodedToken = await this.parseAndValidateToken(idToken);
+
+    if (!decodedToken.email_verified) {
+      this.logger.error(
+        `Unauthorized: user email not verified - user ID: ${decodedToken.uid}. Client should not be making requests with an unverified user.`,
+      );
+
+      throw new ForbiddenException('Forbidden: user email not verified');
+    }
+
+    return decodedToken;
+  }
+
+  private async parseAndValidateToken(token: string): Promise<firebase.auth.DecodedIdToken> {
+    try {
+      const decodedToken = await this.firebase.auth.verifyIdToken(token, this.CHECK_REVOKED);
+
+      return decodedToken;
+    } catch (err) {
+      this.logger.error(`Unauthorized: failed token verification with error: ${err.message}`);
+
+      throw new UnauthorizedException('Unauthorized: token is expired or invalid');
+    }
+  }
+}

--- a/ysm-backend/src/auth/constants.ts
+++ b/ysm-backend/src/auth/constants.ts
@@ -1,1 +1,0 @@
-export const CURRENT_USER_ID_FIELD = 'currentUserId';

--- a/ysm-backend/src/auth/current-user-id.decorator.ts
+++ b/ysm-backend/src/auth/current-user-id.decorator.ts
@@ -1,5 +1,5 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
-import { CURRENT_USER_ID_FIELD } from './constants';
+import { CURRENT_USER_ID_FIELD } from '../constants';
 
 export const CurrentUserId = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
   const request = ctx.switchToHttp().getRequest();

--- a/ysm-backend/src/config.ts
+++ b/ysm-backend/src/config.ts
@@ -10,6 +10,7 @@ export interface Config {
   firebase: {
     serviceAccount: Record<string, string>;
   };
+  contentEditorEmails: string[];
 }
 
 export default (): Config => ({
@@ -20,6 +21,7 @@ export default (): Config => ({
   firebase: {
     serviceAccount: getFirebaseServiceAccount(),
   },
+  contentEditorEmails: getContentEditorEmails(),
 });
 
 function getFirebaseServiceAccount() {
@@ -33,4 +35,21 @@ function getFirebaseServiceAccount() {
 
   const decoded = Buffer.from(data, 'base64').toString('utf-8');
   return JSON.parse(decoded);
+}
+
+function getContentEditorEmails() {
+  const value = process.env.CONTENT_EDITOR_EMAILS;
+
+  if (!value && process.env.NODE_ENV !== 'test') {
+    console.log(
+      `No content editor emails configured. If you'd like to specify some approved content editors (who can view draft content) then set the env var CONTENT_EDITOR_EMAILS with a comma separated list of email addresses.`,
+    );
+
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((v) => v.toLowerCase().trim())
+    .filter((v) => !!v);
 }

--- a/ysm-backend/src/constants.ts
+++ b/ysm-backend/src/constants.ts
@@ -1,0 +1,4 @@
+export const CURRENT_USER_ID_FIELD = 'currentUserId';
+
+export const PREVIEW_MODE_HEADER_NAME = 'x-preview-mode';
+export const PREVIEW_MODE_FIELD = 'isPreviewMode';

--- a/ysm-backend/src/pages/pages.controller.spec.ts
+++ b/ysm-backend/src/pages/pages.controller.spec.ts
@@ -1,20 +1,26 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
+import { PreviewModeGuard } from '../preview-mode/preview-mode.guard';
 import { PagesController } from './pages.controller';
 import { PagesService } from './pages.service';
 import { Page } from './pages.types';
 
 describe('Pages Controller', () => {
   let controller: PagesController;
+  let previewModeGuard: DeepMocked<PreviewModeGuard>;
   let pagesService: DeepMocked<PagesService>;
 
   beforeEach(async () => {
+    previewModeGuard = createMock<PreviewModeGuard>();
     pagesService = createMock<PagesService>();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PagesController],
       providers: [{ provide: PagesService, useValue: pagesService }],
-    }).compile();
+    })
+      .overrideGuard(PreviewModeGuard)
+      .useValue(previewModeGuard)
+      .compile();
 
     controller = module.get<PagesController>(PagesController);
   });
@@ -29,9 +35,9 @@ describe('Pages Controller', () => {
 
       pagesService.get.mockResolvedValueOnce(pageMock);
 
-      expect(await controller.get('foo')).toBe(pageMock);
+      expect(await controller.get('foo', false)).toBe(pageMock);
 
-      expect(pagesService.get).toHaveBeenCalledWith('foo');
+      expect(pagesService.get).toHaveBeenCalledWith('foo', false);
     });
   });
 });

--- a/ysm-backend/src/pages/pages.controller.ts
+++ b/ysm-backend/src/pages/pages.controller.ts
@@ -1,4 +1,6 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { PreviewMode } from '../preview-mode/preview-mode.decorator';
+import { PreviewModeGuard } from '../preview-mode/preview-mode.guard';
 import { PagesService } from './pages.service';
 import { Page } from './pages.types';
 
@@ -7,7 +9,8 @@ export class PagesController {
   constructor(private pagesService: PagesService) {}
 
   @Get(':slug')
-  async get(@Param('slug') slug: string): Promise<Page> {
-    return this.pagesService.get(slug);
+  @UseGuards(PreviewModeGuard)
+  async get(@Param('slug') slug: string, @PreviewMode() previewMode: boolean): Promise<Page> {
+    return this.pagesService.get(slug, previewMode);
   }
 }

--- a/ysm-backend/src/pages/pages.service.ts
+++ b/ysm-backend/src/pages/pages.service.ts
@@ -11,9 +11,11 @@ export class PagesService {
     private pageSerialiserService: PageSerialiserService,
   ) {}
 
-  async get(slug: string): Promise<Page> {
+  async get(slug: string, previewMode: boolean): Promise<Page> {
     try {
-      const response = await this.storyblok.getStory(`pages/${slug}`, { version: 'draft' });
+      const response = await this.storyblok.getStory(`pages/${slug}`, {
+        version: previewMode ? 'draft' : 'published',
+      });
 
       return this.pageSerialiserService.serialise(response.data.story);
     } catch (e) {

--- a/ysm-backend/src/preview-mode/preview-mode.decorator.ts
+++ b/ysm-backend/src/preview-mode/preview-mode.decorator.ts
@@ -1,0 +1,7 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { PREVIEW_MODE_FIELD } from '../constants';
+
+export const PreviewMode = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+  const request = ctx.switchToHttp().getRequest();
+  return !!request[PREVIEW_MODE_FIELD];
+});

--- a/ysm-backend/src/preview-mode/preview-mode.guard.spec.ts
+++ b/ysm-backend/src/preview-mode/preview-mode.guard.spec.ts
@@ -1,0 +1,144 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { ExecutionContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AuthService } from '../auth/auth.service';
+import { PREVIEW_MODE_FIELD, PREVIEW_MODE_HEADER_NAME } from '../constants';
+import { firebase } from '../firebase/firebase.types';
+import { PreviewModeGuard } from './preview-mode.guard';
+
+function mockHeaders(
+  mock: DeepMocked<ExecutionContext>,
+  previewMode: string | undefined,
+  authorization: string | undefined,
+): void {
+  mock.switchToHttp().getRequest.mockReturnValue({
+    headers: {
+      [PREVIEW_MODE_HEADER_NAME]: previewMode,
+      authorization,
+    },
+  });
+}
+
+describe('PreviewModeGuard', () => {
+  let guard: PreviewModeGuard;
+
+  let configService: DeepMocked<ConfigService>;
+  let authService: DeepMocked<AuthService>;
+
+  let mockContext: DeepMocked<ExecutionContext>;
+
+  beforeEach(async () => {
+    configService = createMock<ConfigService>();
+    authService = createMock<AuthService>();
+
+    mockContext = createMock<ExecutionContext>();
+
+    guard = new PreviewModeGuard(configService, authService);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('No preview mode header', () => {
+    it("allows access and doesn't set preview mode on the request", async () => {
+      mockHeaders(mockContext, undefined, undefined);
+
+      expect.assertions(3);
+
+      await expect(guard.canActivate(mockContext)).resolves.toEqual(true);
+
+      expect(authService.parseAuth).not.toHaveBeenCalled();
+
+      expect(mockContext.switchToHttp().getRequest()[PREVIEW_MODE_FIELD]).toBeUndefined();
+    });
+  });
+
+  describe('Preview mode header set', () => {
+    describe("when it's value is 'false'", () => {
+      it("allows access and doesn't set preview mode on the request", async () => {
+        mockHeaders(mockContext, 'false', undefined);
+
+        expect.assertions(3);
+
+        await expect(guard.canActivate(mockContext)).resolves.toEqual(true);
+
+        expect(authService.parseAuth).not.toHaveBeenCalled();
+
+        expect(mockContext.switchToHttp().getRequest()[PREVIEW_MODE_FIELD]).toBeUndefined();
+      });
+    });
+
+    describe("when it's value is 'true'", () => {
+      describe('with no authorization header set', () => {
+        it("doesn't allow access and doesn't set preview mode on the request", async () => {
+          mockHeaders(mockContext, 'true', undefined);
+
+          expect.assertions(3);
+
+          await expect(guard.canActivate(mockContext)).resolves.toEqual(false);
+
+          expect(authService.parseAuth).not.toHaveBeenCalled();
+
+          expect(mockContext.switchToHttp().getRequest()[PREVIEW_MODE_FIELD]).toBeUndefined();
+        });
+      });
+
+      describe('with a valid authorization header set', () => {
+        const authorizationHeader = 'a valid token';
+        let mockDecodedToken: firebase.auth.DecodedIdToken;
+        let emailSpy: jest.Mock<string, []>;
+
+        beforeEach(() => {
+          mockDecodedToken = createMock<firebase.auth.DecodedIdToken>();
+
+          Object.defineProperty(mockDecodedToken, 'uid', { value: '12345' });
+
+          emailSpy = jest.fn(() => 'me@example.org');
+          Object.defineProperty(mockDecodedToken, 'email', { get: emailSpy });
+          authService.parseAuth.mockResolvedValueOnce(mockDecodedToken);
+        });
+
+        describe("when authed email isn't in list of allowed emails", () => {
+          it("doesn't allow access and doesn't set preview mode on the request", async () => {
+            mockHeaders(mockContext, 'true', authorizationHeader);
+
+            configService.get.mockReturnValueOnce(['someone@example.org']);
+
+            expect.assertions(6);
+
+            await expect(guard.canActivate(mockContext)).resolves.toEqual(false);
+
+            expect(configService.get).toHaveBeenCalledWith('contentEditorEmails');
+
+            expect(authService.parseAuth).toHaveBeenCalledTimes(1);
+            expect(authService.parseAuth).toHaveBeenCalledWith(authorizationHeader);
+            expect(emailSpy).toHaveBeenCalledTimes(1);
+
+            expect(mockContext.switchToHttp().getRequest()[PREVIEW_MODE_FIELD]).toBeUndefined();
+          });
+        });
+
+        describe('when authed email is in list of allowed emails', () => {
+          it('allows access and sets preview mode on the request', async () => {
+            mockHeaders(mockContext, 'true', authorizationHeader);
+
+            configService.get.mockReturnValueOnce(['me@example.org']);
+
+            expect.assertions(6);
+
+            await expect(guard.canActivate(mockContext)).resolves.toEqual(true);
+
+            expect(configService.get).toHaveBeenCalledWith('contentEditorEmails');
+
+            expect(authService.parseAuth).toHaveBeenCalledTimes(1);
+            expect(authService.parseAuth).toHaveBeenCalledWith(authorizationHeader);
+            expect(emailSpy).toHaveBeenCalledTimes(1);
+
+            expect(mockContext.switchToHttp().getRequest()[PREVIEW_MODE_FIELD]).toEqual(true);
+          });
+        });
+      });
+    });
+  });
+});

--- a/ysm-backend/src/preview-mode/preview-mode.guard.ts
+++ b/ysm-backend/src/preview-mode/preview-mode.guard.ts
@@ -1,0 +1,44 @@
+import { CanActivate, ExecutionContext, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+import { AuthService } from '../auth/auth.service';
+import { PREVIEW_MODE_FIELD, PREVIEW_MODE_HEADER_NAME } from '../constants';
+
+@Injectable()
+export class PreviewModeGuard implements CanActivate {
+  private logger = new Logger('PreviewModeGuard');
+
+  constructor(private configService: ConfigService, private authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+
+    const { authorization, [PREVIEW_MODE_HEADER_NAME]: isPreviewMode } = request.headers;
+
+    if (!isPreviewMode || isPreviewMode.toString().toLowerCase() === 'false') {
+      return true;
+    }
+
+    if (!authorization) {
+      this.logger.error('Tried to access preview mode without an auth token.');
+
+      return false;
+    }
+
+    const decodedToken = await this.authService.parseAuth(authorization);
+
+    const allowedEmails = this.configService.get<string[]>('contentEditorEmails');
+
+    if (!allowedEmails.includes(decodedToken.email.toLowerCase())) {
+      this.logger.error(
+        `User ${decodedToken.uid} attempted to access preview mode but their email is not in the list of approved content editors.`,
+      );
+
+      return false;
+    }
+
+    request[PREVIEW_MODE_FIELD] = true;
+
+    return true;
+  }
+}

--- a/ysm-backend/src/resources/resources.controller.spec.ts
+++ b/ysm-backend/src/resources/resources.controller.spec.ts
@@ -1,20 +1,26 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { resourcesListFixture, singleResourceFixture } from '../../test/fixtures/resources';
+import { PreviewModeGuard } from '../preview-mode/preview-mode.guard';
 import { ResourcesController } from './resources.controller';
 import { ResourcesService } from './resources.service';
 
 describe('Resources Controller', () => {
   let controller: ResourcesController;
+  let previewModeGuard: DeepMocked<PreviewModeGuard>;
   let resourcesService: DeepMocked<ResourcesService>;
 
   beforeEach(async () => {
+    previewModeGuard = createMock<PreviewModeGuard>();
     resourcesService = createMock<ResourcesService>();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ResourcesController],
       providers: [{ provide: ResourcesService, useValue: resourcesService }],
-    }).compile();
+    })
+      .overrideGuard(PreviewModeGuard)
+      .useValue(previewModeGuard)
+      .compile();
 
     controller = module.get<ResourcesController>(ResourcesController);
   });
@@ -27,7 +33,9 @@ describe('Resources Controller', () => {
     it('should return an array of Resources', async () => {
       resourcesService.list.mockResolvedValueOnce(resourcesListFixture);
 
-      expect(await controller.list(undefined, undefined)).toBe(resourcesListFixture);
+      expect(await controller.list(undefined, undefined, false)).toBe(resourcesListFixture);
+
+      expect(resourcesService.list).toHaveBeenCalledWith(undefined, undefined, false);
     });
   });
 
@@ -35,9 +43,9 @@ describe('Resources Controller', () => {
     it('should return a single Resource', async () => {
       resourcesService.get.mockResolvedValueOnce(singleResourceFixture);
 
-      expect(await controller.get('foo')).toBe(singleResourceFixture);
+      expect(await controller.get('foo', false)).toBe(singleResourceFixture);
 
-      expect(resourcesService.get).toHaveBeenCalledWith('foo');
+      expect(resourcesService.get).toHaveBeenCalledWith('foo', false);
     });
   });
 });

--- a/ysm-backend/src/resources/resources.controller.ts
+++ b/ysm-backend/src/resources/resources.controller.ts
@@ -1,4 +1,6 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { PreviewMode } from '../preview-mode/preview-mode.decorator';
+import { PreviewModeGuard } from '../preview-mode/preview-mode.guard';
 import { FilterOptions } from './filters.types';
 import { Resource } from './resource.types';
 import { ResourcesService } from './resources.service';
@@ -13,15 +15,18 @@ export class ResourcesController {
   }
 
   @Get()
+  @UseGuards(PreviewModeGuard)
   async list(
     @Query('filters') filters: Record<string, string>,
     @Query('q') searchQuery: string,
+    @PreviewMode() previewMode: boolean,
   ): Promise<Resource[]> {
-    return this.resourcesService.list(filters, searchQuery);
+    return this.resourcesService.list(filters, searchQuery, previewMode);
   }
 
   @Get(':slug')
-  async get(@Param('slug') slug: string): Promise<Resource> {
-    return this.resourcesService.get(slug);
+  @UseGuards(PreviewModeGuard)
+  async get(@Param('slug') slug: string, @PreviewMode() previewMode: boolean): Promise<Resource> {
+    return this.resourcesService.get(slug, previewMode);
   }
 }

--- a/ysm-backend/src/resources/resources.service.ts
+++ b/ysm-backend/src/resources/resources.service.ts
@@ -18,11 +18,15 @@ export class ResourcesService {
     return this.filtersService.options(this.storyblok);
   }
 
-  async list(filters: Record<string, string>, searchQuery: string): Promise<Resource[]> {
+  async list(
+    filters: Record<string, string>,
+    searchQuery: string,
+    previewMode: boolean,
+  ): Promise<Resource[]> {
     const params: StoriesParams = {
       starts_with: 'resources/',
       excluding_fields: 'content_items',
-      version: 'draft',
+      version: previewMode ? 'draft' : 'published',
       sort_by: 'position:asc',
       per_page: 100,
       ...this.buildRetrievalParamsForStoryblok(filters, searchQuery),
@@ -32,9 +36,11 @@ export class ResourcesService {
     return response.data.stories.map((s) => this.resourceSerialiserService.serialise(s));
   }
 
-  async get(slug: string): Promise<Resource> {
+  async get(slug: string, previewMode: boolean): Promise<Resource> {
     try {
-      const response = await this.storyblok.getStory(`resources/${slug}`, { version: 'draft' });
+      const response = await this.storyblok.getStory(`resources/${slug}`, {
+        version: previewMode ? 'draft' : 'published',
+      });
 
       if (response.data.story.content.enabled) {
         return this.resourceSerialiserService.serialise(response.data.story);

--- a/ysm-backend/src/themes/themes.controller.spec.ts
+++ b/ysm-backend/src/themes/themes.controller.spec.ts
@@ -1,20 +1,26 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { themesListFixture } from '../../test/fixtures/themes';
+import { PreviewModeGuard } from '../preview-mode/preview-mode.guard';
 import { ThemesController } from './themes.controller';
 import { ThemesService } from './themes.service';
 
 describe('Themes Controller', () => {
   let controller: ThemesController;
+  let previewModeGuard: DeepMocked<PreviewModeGuard>;
   let themesService: DeepMocked<ThemesService>;
 
   beforeEach(async () => {
+    previewModeGuard = createMock<PreviewModeGuard>();
     themesService = createMock<ThemesService>();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ThemesController],
       providers: [{ provide: ThemesService, useValue: themesService }],
-    }).compile();
+    })
+      .overrideGuard(PreviewModeGuard)
+      .useValue(previewModeGuard)
+      .compile();
 
     controller = module.get<ThemesController>(ThemesController);
   });
@@ -27,7 +33,7 @@ describe('Themes Controller', () => {
     it('should return an array of Themes', async () => {
       themesService.list.mockResolvedValueOnce(themesListFixture);
 
-      expect(await controller.list()).toBe(themesListFixture);
+      expect(await controller.list(false)).toBe(themesListFixture);
     });
   });
 });

--- a/ysm-backend/src/themes/themes.controller.ts
+++ b/ysm-backend/src/themes/themes.controller.ts
@@ -1,4 +1,6 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { PreviewMode } from '../preview-mode/preview-mode.decorator';
+import { PreviewModeGuard } from '../preview-mode/preview-mode.guard';
 import { Theme } from './theme.types';
 import { ThemesService } from './themes.service';
 
@@ -7,7 +9,8 @@ export class ThemesController {
   constructor(private themesService: ThemesService) {}
 
   @Get()
-  async list(): Promise<Theme[]> {
-    return this.themesService.list();
+  @UseGuards(PreviewModeGuard)
+  async list(@PreviewMode() previewMode: boolean): Promise<Theme[]> {
+    return this.themesService.list(previewMode);
   }
 }

--- a/ysm-backend/src/themes/themes.service.ts
+++ b/ysm-backend/src/themes/themes.service.ts
@@ -11,10 +11,10 @@ export class ThemesService {
     private themeSerialiserService: ThemeSerialiserService,
   ) {}
 
-  async list(): Promise<Theme[]> {
+  async list(previewMode: boolean): Promise<Theme[]> {
     const params: StoriesParams = {
       starts_with: 'themes/',
-      version: 'draft',
+      version: previewMode ? 'draft' : 'published',
     };
 
     const response = await this.storyblok.getStories(params);

--- a/ysm-backend/test/themes.e2e-spec.ts
+++ b/ysm-backend/test/themes.e2e-spec.ts
@@ -1,20 +1,26 @@
 import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { when } from 'jest-when';
+import { nanoid } from 'nanoid';
 import StoryblokClient, { StoriesParams } from 'storyblok-js-client';
 import request from 'supertest';
 import { mocked } from 'ts-jest/utils';
+import { FIREBASE } from '../src/firebase/firebase-factory';
+import { FirebaseServices } from '../src/firebase/firebase.types';
 import { AppModule } from './../src/app.module';
 import { storyblokThemesListFixture } from './fixtures/storyblok';
 import { themesListFixture } from './fixtures/themes';
+import { generateIdToken } from './util/generate-id-token';
+import { mockConfigService } from './util/mock-config-service';
 
 jest.mock('storyblok-js-client');
 const mockedStoryblokClient = mocked(StoryblokClient, true);
 
-function mockGetStories(instance: StoryblokClient, data: any): void {
+function mockGetStories(instance: StoryblokClient, data: any, previewMode = false): void {
   const params: StoriesParams = {
     starts_with: 'themes/',
-    version: 'draft',
+    version: previewMode ? 'draft' : 'published',
   };
 
   when(mocked(instance.getStories))
@@ -24,6 +30,13 @@ function mockGetStories(instance: StoryblokClient, data: any): void {
 
 describe('Themes (e2e)', () => {
   let app: INestApplication;
+
+  let firebaseServices: FirebaseServices;
+  const userId = `e2e-themes-${nanoid(8)}`;
+  const userEmail = 'test@example.org';
+  let authToken: string;
+
+  let configService: ConfigService;
 
   afterAll(async () => {
     await app.close();
@@ -40,6 +53,17 @@ describe('Themes (e2e)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
+
+    configService = app.get<ConfigService>(ConfigService);
+    mockConfigService(configService, 'contentEditorEmails', []);
+
+    firebaseServices = app.get<FirebaseServices>(FIREBASE);
+
+    // Only set auth token once as we don't need it renewed on every test case.
+    if (!authToken) {
+      authToken = await generateIdToken(firebaseServices.auth, userId, userEmail);
+      // console.log(`authToken = ${authToken}`);
+    }
   });
 
   describe('GET /themes', () => {
@@ -70,6 +94,45 @@ describe('Themes (e2e)', () => {
           .get('/themes')
           .expect('Content-Type', /json/)
           .expect(200, themesListFixture);
+      });
+    });
+
+    describe('preview mode', () => {
+      describe('without any auth', () => {
+        it('should return 403 Forbidden', async () => {
+          // Precondition:
+          expect(configService.get<string[]>('contentEditorEmails')).toEqual([]);
+
+          await request(app.getHttpServer())
+            .get('/resources')
+            .set('X-PREVIEW-MODE', 'true')
+            .expect('Content-Type', /json/)
+            .expect(403);
+
+          expect(mockedStoryblokClient.mock.instances[0].getStories).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('with allowed auth', () => {
+        beforeEach(() => {
+          mockConfigService(configService, 'contentEditorEmails', [userEmail]);
+
+          const mockedStoryblokClientInstance = mockedStoryblokClient.mock.instances[0];
+
+          mockGetStories(mockedStoryblokClientInstance, storyblokThemesListFixture, true);
+        });
+
+        it('should return the draft list of resources', () => {
+          // Precondition:
+          expect(configService.get<string[]>('contentEditorEmails')).toEqual([userEmail]);
+
+          return request(app.getHttpServer())
+            .get('/themes')
+            .set('Authorization', `Bearer ${authToken}`)
+            .set('X-PREVIEW-MODE', 'true')
+            .expect('Content-Type', /json/)
+            .expect(200, themesListFixture);
+        });
       });
     });
   });

--- a/ysm-backend/test/util/generate-id-token.ts
+++ b/ysm-backend/test/util/generate-id-token.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import { FirebaseAuth } from '../../src/firebase/firebase.types';
+
+export async function generateIdToken(
+  auth: FirebaseAuth,
+  userId: string,
+  email: string,
+): Promise<string> {
+  const firebaseWebApiKey = process.env.FIREBASE_WEB_API_KEY;
+
+  if (!firebaseWebApiKey) {
+    throw new Error(
+      `Missing FIREBASE_WEB_API_KEY env var for e2e tests - place this in .env.test.local`,
+    );
+  }
+
+  const customToken = await auth.createCustomToken(userId, { email, email_verified: true });
+
+  const url = `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${firebaseWebApiKey}`;
+  const result = await axios.post(url, {
+    token: customToken,
+    returnSecureToken: true,
+  });
+
+  return result.data.idToken as string;
+}

--- a/ysm-backend/test/util/mock-config-service.ts
+++ b/ysm-backend/test/util/mock-config-service.ts
@@ -1,0 +1,7 @@
+import { ConfigService } from '@nestjs/config';
+import { when } from 'jest-when';
+
+export function mockConfigService<T>(instance: ConfigService, key: string, value: T): void {
+  const spy = jest.spyOn(instance, 'get');
+  when(spy).expectCalledWith(key, undefined).mockReturnValue(value);
+}


### PR DESCRIPTION
IMPORTANT: now only **published** content will be returned by default, unless preview mode is "activated" by the frontend.

Two key aspects control _how_ and _who_ gets to see **draft** content from Storyblok:

1. To signal that an API request should work in preview mode and attempt to fetch **draft** content, the client needs to set a new header in each API request: `X-PREVIEW-MODE` (value can be anything apart from a falsey value or the string 'false').

2. Only authenticated API requests (i.e. with the Firebase Auth token) will be allowed to do this, AND only certain users that have their email address present in the new env var `CONTENT_EDITOR_EMAILS` (which the backend safelists against).

So if the preview header is set and, either no auth is provided or auth for a user that's not allowed is provided, then a `403 Forbidden` is returned.