### PR TITLE
[backend] Improved auth user handling for e2e test suite

### DIFF
--- a/ysm-backend/test/util/auth-user.ts
+++ b/ysm-backend/test/util/auth-user.ts
@@ -1,0 +1,6 @@
+import { nanoid } from 'nanoid';
+
+export const authUser = {
+  uid: `e2e-user-${nanoid(8)}`,
+  email: 'test@example.org',
+};

--- a/ysm-backend/test/util/delete-user.ts
+++ b/ysm-backend/test/util/delete-user.ts
@@ -1,0 +1,5 @@
+import { FirebaseAuth } from '../../src/firebase/firebase.types';
+
+export async function deleteUser(auth: FirebaseAuth, uid: string): Promise<void> {
+  return auth.deleteUser(uid);
+}

--- a/ysm-backend/test/util/generate-id-token.ts
+++ b/ysm-backend/test/util/generate-id-token.ts
@@ -3,7 +3,7 @@ import { FirebaseAuth } from '../../src/firebase/firebase.types';
 
 export async function generateIdToken(
   auth: FirebaseAuth,
-  userId: string,
+  uid: string,
   email: string,
 ): Promise<string> {
   const firebaseWebApiKey = process.env.FIREBASE_WEB_API_KEY;
@@ -14,7 +14,7 @@ export async function generateIdToken(
     );
   }
 
-  const customToken = await auth.createCustomToken(userId, { email, email_verified: true });
+  const customToken = await auth.createCustomToken(uid, { email, email_verified: true });
 
   const url = `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${firebaseWebApiKey}`;
   const result = await axios.post(url, {


### PR DESCRIPTION
We now only use one authed user per test run and delete that user afterwards. This ensures that user accounts don't keep piling up in Firease Auth.