### PR TITLE
fix hotjar NPS stylesheet import - rm preload

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -12,7 +12,7 @@ export default class MyDocument extends Document {
             rel="stylesheet"
             href="https://fonts.googleapis.com/css?family=Nunito&display=swap"
           />
-          <link href="https://bloom.chayn.co/hotjarNPS.css" rel="preload" as="style" />
+          <link rel="stylesheet" href="https://bloom.chayn.co/hotjarNPS.css" />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
### What changes did you make?
Removed preload as this was causing a warning and not fixing the stylesheet import (not loading)


